### PR TITLE
add helper cmd to rollback state to pred. block

### DIFF
--- a/apps/src/bin/anoma-node/cli.rs
+++ b/apps/src/bin/anoma-node/cli.rs
@@ -12,9 +12,13 @@ pub fn main() -> Result<()> {
             cmds::Ledger::Run(_) => {
                 ledger::run(ctx.config.ledger, ctx.config.wasm_dir);
             }
+            cmds::Ledger::Rollback(_) => {
+                ledger::rollback(ctx.config.ledger)
+                    .wrap_err("Failed to rollback the Anoma ledger node")?;
+            }
             cmds::Ledger::Reset(_) => {
                 ledger::reset(ctx.config.ledger)
-                    .wrap_err("Failed to reset Anoma node")?;
+                    .wrap_err("Failed to reset the Anoma ledger node")?;
             }
         },
         cmds::AnomaNode::Gossip(sub) => match sub {

--- a/apps/src/lib/node/ledger/mod.rs
+++ b/apps/src/lib/node/ledger/mod.rs
@@ -129,6 +129,11 @@ impl Shell {
     }
 }
 
+/// Rollback the state to the predecessor block height.
+pub fn rollback(config: config::Ledger) -> Result<(), shell::Error> {
+    shell::rollback(config)
+}
+
 /// Resets the tendermint_node state and removes database files
 pub fn reset(config: config::Ledger) -> Result<(), shell::Error> {
     shell::reset(config)

--- a/apps/src/lib/node/ledger/tendermint_node.rs
+++ b/apps/src/lib/node/ledger/tendermint_node.rs
@@ -153,6 +153,16 @@ fn monitor_process(
     });
 }
 
+pub fn rollback(tendermint_dir: impl AsRef<Path>) -> Result<()> {
+    let tendermint_dir = tendermint_dir.as_ref().to_string_lossy();
+    // reset all the Tendermint state, if any
+    Command::new("tendermint")
+        .args(&["rollback", "--home", &tendermint_dir])
+        .output()
+        .expect("Failed to rollback Tendermint");
+    Ok(())
+}
+
 pub fn reset(tendermint_dir: impl AsRef<Path>) -> Result<()> {
     let tendermint_dir = tendermint_dir.as_ref().to_string_lossy();
     // reset all the Tendermint state, if any

--- a/scripts/install/get_tendermint.sh
+++ b/scripts/install/get_tendermint.sh
@@ -3,9 +3,9 @@
 #set -x
 
 # an examplary download-url
-# https://github.com/tendermint/tendermint/releases/download/v0.34.13/tendermint_0.34.13_linux_amd64.tar.gz
+# https://github.com/tendermint/tendermint/releases/download/v0.34.14/tendermint_0.34.14_linux_amd64.tar.gz
 export TM_MAJORMINOR="0.34"
-export TM_PATCH="13"
+export TM_PATCH="14"
 export TM_REPO="https://github.com/tendermint/tendermint"
 
 export TM_VERSION="${TM_MAJORMINOR}.${TM_PATCH}"

--- a/shared/src/ledger/storage/mockdb.rs
+++ b/shared/src/ledger/storage/mockdb.rs
@@ -242,6 +242,11 @@ impl DB for MockDB {
             }),
         }
     }
+
+    fn rollback_state(&mut self) -> Result<BlockHeight> {
+        // We do not keep predecessor blocks data in mock DB
+        unimplemented!("MockDB doesn't support state rollback")
+    }
 }
 
 impl<'iter> DBIter<'iter> for MockDB {


### PR DESCRIPTION
closes anoma/namada#39

There are 2 to-dos in Anoma:


* [ ] tx queue rollback (we only have them for the current block atm) anoma/anoma#711 
* [ ] storage values `next_epoch_min_start_height` and `next_epoch_min_start_time` rollback (also known only for the current block) anoma/anoma#729

And one blocking issue in Tendermint:


* https://github.com/tendermint/tendermint/issues/7304



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201757896515792/1201763182439874) by [Unito](https://www.unito.io)
