### PR TITLE
Update to transaction hashing and encryption.

### DIFF
--- a/apps/src/lib/node/ledger/shell/finalize_block.rs
+++ b/apps/src/lib/node/ledger/shell/finalize_block.rs
@@ -752,10 +752,17 @@ mod test_finalize_block {
         let keypair = crate::wallet::defaults::daewon_keypair();
         let pubkey = EncryptionKey::default();
         // not valid tx bytes
-        let tx = "garbage data".as_bytes().to_owned();
+        let tx_code = "garbage code".as_bytes().to_owned();
+        let tx_code_hash = &hash_tx(tx_code).0;
+        let tx_data = "garbage data".as_bytes().to_owned();
+        let ts = "01/10/1995".as_bytes();
         let inner_tx =
             anoma::types::transaction::encrypted::EncryptedTx::encrypt(
-                &tx, pubkey,
+                tx_code_hash,
+                tx_code,
+                tx_data,
+                ts,
+                pubkey,
             );
         let wrapper = WrapperTx {
             fee: Fee {
@@ -809,10 +816,18 @@ mod test_finalize_block {
         let keypair = crate::wallet::defaults::daewon_keypair();
         let pubkey = EncryptionKey::default();
         // not valid tx bytes
-        let tx = "garbage data".as_bytes().to_owned();
+        let tx_code = "garbage code".as_bytes().to_owned();
+        let tx_data = "garbage data".as_bytes().to_owned();
+        let tx = Tx::new(tx_code,Some(tx_data));
+        let (hash_to_encrypt,code_to_encrypt,
+            data_to_encrypt, ts_to_encrypt) = tx.tx_to_encrypt();
         let inner_tx =
             anoma::types::transaction::encrypted::EncryptedTx::encrypt(
-                &tx, pubkey,
+                &hash_to_encrypt,
+                &code_to_encrypt,
+                &data_to_encrypt,
+                &ts_to_encrypt,
+                pubkey,
             );
         let wrapper = WrapperTx {
             fee: Fee {
@@ -823,7 +838,7 @@ mod test_finalize_block {
             epoch: Epoch(0),
             gas_limit: 0.into(),
             inner_tx,
-            tx_hash: hash_tx(&tx),
+            tx_hash: hash_tx(&tx.to_bytes()),
         };
         let processed_tx = ProcessedTx {
             tx: Tx::from(TxType::Decrypted(DecryptedTx::Undecryptable(

--- a/apps/src/lib/node/ledger/shell/process_proposal.rs
+++ b/apps/src/lib/node/ledger/shell/process_proposal.rs
@@ -751,8 +751,19 @@ mod test_process_proposal {
         let keypair = crate::wallet::defaults::daewon_keypair();
         let pubkey = EncryptionKey::default();
         // not valid tx bytes
-        let tx = "garbage data".as_bytes().to_owned();
-        let inner_tx = EncryptedTx::encrypt(&tx, pubkey);
+        let tx_code = "garbage code".as_bytes().to_owned();
+        let tx_data = "garbage data".as_bytes().to_owned().clone();
+        let tx_timestamp = "garbage timestamp".as_bytes().to_owned().clone();
+        let tx = [tx_code.clone(),tx_data.clone(),tx_timestamp.clone()].concat();
+        let tx :&[u8] = &tx;
+        let inner_tx =
+            EncryptedTx::encrypt(
+                &tx_code,
+                &tx_code,
+                &tx_data,
+                &tx_timestamp,
+                pubkey,
+            );
         let wrapper = WrapperTx {
             fee: Fee {
                 amount: 0.into(),

--- a/shared/src/types/transaction/encrypted.rs
+++ b/shared/src/types/transaction/encrypted.rs
@@ -174,49 +174,56 @@ pub mod encrypted_tx {
         }
     }
 
+    #[derive(Debug, BorshSerialize, BorshDeserialize)]
+    pub struct EncryptedTxFields {
+        pub nonce_code_hash : Vec<u8>,
+        pub ciphertext_code_hash : Vec<u8>,
+        pub auth_tag_code_hash : Vec<u8>,
+        pub nonce_code : Vec<u8>,
+        pub ciphertext_code : Vec<u8>,
+        pub auth_tag_code : Vec<u8>,
+        pub nonce_data : Vec<u8>,
+        pub ciphertext_data : Vec<u8>,
+        pub auth_tag_data : Vec<u8>,
+        pub nonce_ts : Vec<u8>,
+        pub ciphertext_ts : Vec<u8>,
+        pub auth_tag_ts : Vec<u8>,
+    }
+
     impl borsh::BorshDeserialize for EncryptedTx {
         fn deserialize(buf: &mut &[u8]) -> std::io::Result<Self> {
-            type VecTuple = (Vec<u8>, Vec<u8>, Vec<u8>,
-                             Vec<u8>, Vec<u8>, Vec<u8>,
-                             Vec<u8>, Vec<u8>, Vec<u8>,
-                             Vec<u8>, Vec<u8>, Vec<u8>);
-            let (
-                nonce_code_hash, ciphertext_code_hash, auth_tag_code_hash,
-                nonce_code, ciphertext_code, auth_tag_code,
-                nonce_data, ciphertext_data, auth_tag_data,
-                nonce_ts, ciphertext_ts, auth_tag_ts
-            ): VecTuple =
+            let encrypted_tx : EncryptedTxFields =
                 BorshDeserialize::deserialize(buf)?;
             Ok(
                 EncryptedTx{
                     encrypted_code_hash : Ciphertext {
-                        nonce: CanonicalDeserialize::deserialize(&*nonce_code_hash)
+                        nonce: CanonicalDeserialize::deserialize(&*encrypted_tx.nonce_code_hash)
                             .map_err(|err| Error::new(ErrorKind::InvalidData, err))?,
-                        ciphertext:ciphertext_code_hash,
-                        auth_tag: CanonicalDeserialize::deserialize(&*auth_tag_code_hash)
+                        ciphertext: encrypted_tx.ciphertext_code_hash,
+                        auth_tag: CanonicalDeserialize::deserialize(&*encrypted_tx.auth_tag_code_hash)
                             .map_err(|err| Error::new(ErrorKind::InvalidData, err))?,
                     },
                     encrypted_code : Ciphertext {
-                        nonce: CanonicalDeserialize::deserialize(&*nonce_code)
+                        nonce: CanonicalDeserialize::deserialize(&*encrypted_tx.nonce_code)
                             .map_err(|err|
                                 Error::new(ErrorKind::InvalidData, err))?,
-                        ciphertext:ciphertext_code,
-                        auth_tag: CanonicalDeserialize::deserialize(&*auth_tag_code)
+                        ciphertext:encrypted_tx.ciphertext_code,
+                        auth_tag: CanonicalDeserialize::deserialize(&*encrypted_tx.auth_tag_code)
                             .map_err(|err|
                                 Error::new(ErrorKind::InvalidData, err))?,
                     },
                     encrypted_data : Ciphertext {
-                        nonce: CanonicalDeserialize::deserialize(&*nonce_data)
+                        nonce: CanonicalDeserialize::deserialize(&*encrypted_tx.nonce_data)
                             .map_err(|err| Error::new(ErrorKind::InvalidData, err))?,
-                        ciphertext:ciphertext_data,
-                        auth_tag: CanonicalDeserialize::deserialize(&*auth_tag_data)
+                        ciphertext: encrypted_tx.ciphertext_data,
+                        auth_tag: CanonicalDeserialize::deserialize(&*encrypted_tx.auth_tag_data)
                             .map_err(|err| Error::new(ErrorKind::InvalidData, err))?,
                     },
                     encrypted_ts : Ciphertext {
-                        nonce: CanonicalDeserialize::deserialize(&*nonce_ts)
+                        nonce: CanonicalDeserialize::deserialize(&*encrypted_tx.nonce_ts)
                             .map_err(|err| Error::new(ErrorKind::InvalidData, err))?,
-                        ciphertext:ciphertext_ts,
-                        auth_tag: CanonicalDeserialize::deserialize(&*auth_tag_ts)
+                        ciphertext: encrypted_tx.ciphertext_ts,
+                        auth_tag: CanonicalDeserialize::deserialize(&*encrypted_tx.auth_tag_ts)
                             .map_err(|err| Error::new(ErrorKind::InvalidData, err))?,
                     }
                 })

--- a/shared/src/types/transaction/mod.rs
+++ b/shared/src/types/transaction/mod.rs
@@ -300,7 +300,7 @@ pub mod tx_types {
                 data: Some(data.clone()),
                 timestamp: tx.timestamp,
             }
-            .hash();
+            .tx_to_sign();
             match TxType::try_from(Tx {
                 code: vec![],
                 data: Some(data),


### PR DESCRIPTION
main points:
Instead of signing the hash of the whole transaction:
Sign(Hash( (code || data || timestamp))),
one now signs the hash of the hash of the code, concatenated to the data and timestamp:
Sign(Hash( (Hash(code) || data || timestamp))),

This is so that we can pass the code hash to the device instead of the whole code field.

We also encrypt in parts, so that we can work with unencrypted data